### PR TITLE
Add APNG Options: dispose_op & blend_op

### DIFF
--- a/AnimatedPngCreator/AnimatedPngCreator.cs
+++ b/AnimatedPngCreator/AnimatedPngCreator.cs
@@ -117,11 +117,11 @@ namespace CMK
             init();
         }
 
-        public void WriteFrame(Image image, short frameDelay, int offsetX = 0, int offsetY = 0)
+        public void WriteFrame(Image image, short frameDelay, int offsetX = 0, int offsetY = 0, byte disposeOption = 0, byte blendOption = 1)
         {
             var img = config.FilterUnchangedPixels == true ?
                 changeAnalyser.BlackoutImage(image, out bool b) : image;
-            creator.WriteFrame(img, frameDelay, offsetX, offsetY);
+            creator.WriteFrame(img, frameDelay, offsetX, offsetY, disposeOption, blendOption);
         }
 
         public void Dispose()

--- a/AnimatedPngCreator/Creator.cs
+++ b/AnimatedPngCreator/Creator.cs
@@ -104,7 +104,7 @@ namespace CMK
             _writer.Write(getSwappedCrc(text3));
         }
 
-        private void write_fcTL(int x, int y, int offsetX, int offsetY, short frameDelay) // Frame Control Chunk
+        private void write_fcTL(int x, int y, int offsetX, int offsetY, short frameDelay, byte disposeOption, byte blendOption) // Frame Control Chunk
         {
             //Prepare data
             List<Byte> chunk = new List<byte>();
@@ -126,7 +126,7 @@ namespace CMK
             chunk.AddRange(_offsetY);
             chunk.AddRange(_DefaultFrameDelay);
             chunk.AddRange(new Byte[] { 3, 232 });
-            chunk.AddRange(new Byte[] { 0, 1 });
+            chunk.AddRange(new Byte[] { disposeOption, blendOption });
 
             //Write data
             _writer.Write(chunk.ToArray());
@@ -226,7 +226,7 @@ namespace CMK
         /// <param name="Image">The image to add</param>
         /// <param name="offsetX">X offset to render the image</param>
         /// <param name="offsetY">Y offset to render the image</param>
-        public void WriteFrame(Image image, short frameDelay, int offsetX = 0, int offsetY = 0)
+        public void WriteFrame(Image image, short frameDelay, int offsetX = 0, int offsetY = 0, byte disposeOption = 0, byte blendOption = 1)
         {
             using (Stream png = new MemoryStream())
             {
@@ -238,7 +238,7 @@ namespace CMK
                     write_tEXt_signature();
                     write_acTL_placeholder();
                 }
-                write_fcTL(image.Width, image.Height, offsetX, offsetY, frameDelay);
+                write_fcTL(image.Width, image.Height, offsetX, offsetY, frameDelay, disposeOption, blendOption);
                 if (FrameCount == 1)
                     write_IDAT(png);
                 else


### PR DESCRIPTION
In the project, we dispose_op in fcTL is fixed to 0
so frame will be stacked on previous frame.

For transparent images, previous frame should be cleared out,
so we have to add some parameters at "WriteFrame" to override dispose_op.

+ For someone who wants to override blend_op, I also add the parameter to override it.